### PR TITLE
build fixes, use standard DESTDIR, add LIBDIR

### DIFF
--- a/configure
+++ b/configure
@@ -35,6 +35,7 @@ PKGCONFIG_VERSION=;
 PLATFORM=;
 PLATFORM_VERSION=;
 PREFIX="/usr/local";
+LIBDIR="/usr/lib";
 MANDIR=;
 PROTOCOLS="mext series 40h";
 LIBUDEV_VERSION=;
@@ -370,7 +371,7 @@ determine_mandir() {
 }
 
 determine_pkgconfigdir() {
-	TRY_PKGCONFIGPATHS=/usr/lib/pkgconfig:$PREFIX/lib/pkgconfig:$PKG_CONFIG_PATH
+	TRY_PKGCONFIGPATHS=$LIBDIR/pkgconfig:$PKG_CONFIG_PATH
 
 	for DIR in `echo $TRY_PKGCONFIGPATHS | tr ':' ' '`; do
 		if [ -d $DIR ]; then
@@ -398,6 +399,7 @@ usage () {
 	echo ""
 	echo "  options [and defaults] are:"
 	echo "    --prefix=DIR                install files in PREFIX [/usr/local]"
+	echo "    --libdir=DIR                lib directory [/usr/lib]"
 	echo "    --lo-prefix=DIR             the prefix under which liblo is installed [/usr/local]"
 	echo "    --python-install-dir=DIR    the directory in which the python binding will be installed [python's site-packages dir by default]"
 	echo ""
@@ -421,6 +423,10 @@ while [ -n "$1" ]; do
 		--prefix=*)
 			fail_if_not_dir $arg;
 			PREFIX=$arg;;
+
+		--libdir=*)
+			fail_if_not_dir $arg;
+			LIBDIR=$arg;;
 
 		--lo-prefix=*)
 			fail_if_not_dir $arg;
@@ -674,7 +680,7 @@ export VERSION    = $VERSION
 
 export PREFIX     = $PREFIX
 export BINDIR     = \$(DESTDIR)$PREFIX/bin
-export LIBDIR     = \$(DESTDIR)$PREFIX/lib
+export LIBDIR     = \$(DESTDIR)$LIBDIR
 export INCDIR     = \$(DESTDIR)$PREFIX/include
 export MANDIR     = \$(DESTDIR)$MANDIR
 export PKGCONFIGDIR = \$(DESTDIR)$PKGCONFIGDIR


### PR DESCRIPTION
This allows distributions to use the standard DESTDIR function of autotools. Now people don't need to mess with setting prefix manually, depending on what their systems will do. Also add LIBDIR option, to make it easier for folks that are building on 64-bit, 32-bit, or mixed systems, where the dir is not always /usr/lib, but could be /usr/lib32 or /usr/lib64 or anything else. Also improved the LIBDIR search paths, to remove some redundancies, and work with the existing variables in the configure script.

This is what I had before, to make sure that stuff ends up where it's supposed to across systems:

make BINDIR="${D}"/usr/bin LIBDIR="${D}"/usr/$(get_libdir) \
INCDIR="${D}"/usr/include MANDIR="${D}"/usr/share/man \
PKGCONFIGDIR="${D}"/usr/$(get_libdir)/pkgconfig install

Now, it's just:

make DESTDIR="${D}" install

... where ${D} is the sandbox/destination directory where stuff will be merged. This is a similar fix to the one I made for rove yesterday. Tryin' to get a nicer autotools build system, especially for packagers!
