### PR TITLE
monome_log(), monome_error_set() and rewrite libudev implementation of monome_platform_get_dev_serial()

### DIFF
--- a/src/libmonome.c
+++ b/src/libmonome.c
@@ -55,6 +55,27 @@ static monome_devmap_t *map_serial_to_device(const char *serial) {
 	return NULL;
 }
 
+void monome_debug(const char * format, ...)
+{
+	static int g_verbose = -1;
+	va_list ap;
+
+	if (g_verbose < 0) {
+		g_verbose = getenv("MONOME_VERBOSE") != NULL;
+	}
+
+	if (!g_verbose)
+		return;
+
+	printf("DEBUG: ");
+
+	va_start(ap, format);
+	vprintf(format, ap);
+	va_end(ap);
+
+	printf("\n");
+}
+
 /**
  * public
  */

--- a/src/libmonome.c
+++ b/src/libmonome.c
@@ -76,6 +76,32 @@ void monome_debug(const char * format, ...)
 	printf("\n");
 }
 
+void monome_error_init(monome_error_t * error)
+{
+	*error = malloc(MONOME_MAX_ERROR_STRING_SIZE);
+}
+
+void monome_error_set(monome_error_t error, const char * format, ...)
+{
+	va_list ap;
+
+	if (error == NULL) return;
+
+	va_start(ap, format);
+	vsnprintf((char *)error, MONOME_MAX_ERROR_STRING_SIZE, format, ap);
+	va_end(ap);
+}
+
+const char * monome_error_get(monome_error_t error)
+{
+	return (const char *)error;
+}
+
+void monome_error_uninit(monome_error_t error)
+{
+	free(error);
+}
+
 /**
  * public
  */

--- a/src/platform/linux_libudev.c
+++ b/src/platform/linux_libudev.c
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2010 William Light <wrl@illest.net>
+ * Copyright (c) 2013 Nedko Arnaudov <nedko@arnaudov.name>
  * 
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
@@ -21,64 +21,136 @@
 #include <string.h>
 #include <assert.h>
 #include <libudev.h>
+#include <errno.h>
 
 #include "platform.h"
 
-static char *get_monome_information(struct udev_device *d) {
-	const char *serial, *tty;
+int monome_platform_get_udev_info(const char * device, char ** serial_ptr_ptr, char ** devnode_ptr_ptr, monome_error_t error)
+{
+	int ret;
+	struct stat statbuf;
+	struct udev * udev;
+	const char * serial;
+	const char * devnode;
+	struct udev_device * udev_device;
 
-	assert(d);
+	assert(device != NULL);
+	assert(serial_ptr_ptr != NULL || devnode_ptr_ptr != NULL);
 
-	if( !(tty    = udev_device_get_devnode(d)) ||
-		!(serial = udev_device_get_property_value(d, "ID_SERIAL_SHORT")) )
-		return NULL;
-
-	return strdup(serial);
-}
-
-static char *get_monome_information_from_syspath(struct udev *udev,
-                                                 const char *syspath) {
-	struct udev_device *d = NULL;
-	char *serial;
-
-	assert(syspath);
-	if( !(d = udev_device_new_from_syspath(udev, syspath)) )
-		return NULL;
-
-	serial = get_monome_information(d);
-	udev_device_unref(d);
-
-	return serial;
-}
-
-char *monome_platform_get_dev_serial(const char *device) {
-	struct udev *udev;
-	struct udev_enumerate *ue;
-	struct udev_list_entry *c;
-	const char *syspath;
-	char *serial = NULL;
-
-	assert(device);
+	monome_debug("device is \"%s\"", device);
 
 	udev = udev_new();
+	if (udev == NULL) {
+		monome_error_set(error, "Creation of udev library context failed");
+		ret = -1;
+		goto exit;
+	}
 
-	ue = udev_enumerate_new(udev);
-	udev_enumerate_add_match_property(ue, "DEVNAME", device);
+	if (stat(device, &statbuf) != 0) {
+		if (device[0] != 0 && errno == ENOENT) goto device_id;
+		ret = errno;
+		monome_error_set(error, "Cannot check \"%s\" file type. %s", device, strerror(errno));
+		goto unref_udev;
+	}
 
-	if( udev_enumerate_scan_devices(ue) )
-		goto err_scan;
+	if (S_ISCHR(statbuf.st_mode)) {
+		monome_debug("character device %d:%d", major(statbuf.st_rdev), minor(statbuf.st_rdev));
 
-	c = udev_enumerate_get_list_entry(ue);
+		udev_device = udev_device_new_from_devnum(udev, 'c', statbuf.st_rdev);
+		if (udev_device == NULL) {
+			monome_error_set(error, "cannot open udev by syspath \"%s\"", device);
+			ret = -1;
+			goto unref_udev;
+		}
+	} else if (device[0] == '/') {
+		monome_debug("starts with slash, assuming syspath");
+		udev_device = udev_device_new_from_syspath(udev, device);
+		if (udev_device == NULL) {
+			monome_error_set(error, "cannot open udev by syspath \"%s\"", device);
+			ret = -1;
+			goto unref_udev;
+		}
+	} else {
+	device_id:
+#if HAVE_UDEV_DEVICE_NEW_FROM_DEVICE_ID
+		monome_debug("assuming libudev device id format");
+		udev_device = udev_device_new_from_device_id(udev, (char *)device);
+		//monome_debug("path=\"%s\"", device); // why udev_device_new_from_device_id() wants non-const string?
+		if (udev_device == NULL) {
+			monome_error_set(error, "cannot open udev by device id \"%s\"", device);
+			ret = -1;
+			goto unref_udev;
+		}
+#else
+			monome_error_set(error, "open udev by device id support is not available, cannot open \"%s\" with other methods", device);
+			ret = -1;
+			goto unref_udev;
+#endif
+	}
 
-	if( !(syspath = udev_list_entry_get_name(c)) )
-		goto err_nodevs; /* should NOT happen ever but whatever... */
+	devnode = udev_device_get_devnode(udev_device);
+	if (devnode == NULL) {
+		monome_error_set(error, "device without devnode");
+		ret = -1;
+		goto unref_udev_device;
+	}
 
-	serial = get_monome_information_from_syspath(udev, syspath);
+	monome_debug("devnode is \"%s\"", devnode);
 
-err_nodevs:
-	udev_enumerate_unref(ue);
-err_scan:
+	serial = udev_device_get_property_value(udev_device, "ID_SERIAL_SHORT");
+	if (serial == NULL) {
+		monome_error_set(error, "device without ID_SERIAL_SHORT property");
+		ret = -1;
+		goto unref_udev_device;
+	}
+
+	monome_debug("serial is \"%s\"", serial);
+
+	if (serial_ptr_ptr != NULL) {
+		*serial_ptr_ptr = strdup(serial);
+		if (*serial_ptr_ptr == NULL) {
+			monome_error_set(error, "Out of memory (strdup(serial))");
+			goto unref_udev_device;
+		}
+	}
+
+	if (devnode_ptr_ptr != NULL) {
+		*devnode_ptr_ptr = strdup(devnode);
+		if (*devnode_ptr_ptr == NULL) {
+			monome_error_set(error, "Out of memory (strdup(devnode))");
+			goto free_serial;
+		}
+	}
+
+	ret = 0;
+	goto unref_udev_device;
+
+free_serial:
+	if (serial_ptr_ptr != NULL) free(*serial_ptr_ptr);
+unref_udev_device:
+	udev_device_unref(udev_device);
+unref_udev:
 	udev_unref(udev);
+exit:
+	return ret;
+}
+
+char * monome_platform_get_dev_serial(const char * device)
+{
+	int ret;
+	monome_error_t err;
+	char * serial;
+
+	monome_error_init(&err);
+
+	ret = monome_platform_get_udev_info(device, &serial, NULL, err);
+	if (ret != 0) {
+		fprintf(stderr, "%s (%d)\n", monome_error_get(err), ret);
+		monome_error_uninit(err);
+		return NULL;
+	}
+
+	monome_error_uninit(err);
 
 	return serial;
 }

--- a/src/private/internal.h
+++ b/src/private/internal.h
@@ -149,4 +149,6 @@ struct monome {
 	monome_tilt_functions_t *tilt;
 };
 
+void monome_debug(const char * format, ...);
+
 #endif /* defined MONOME_INTERNAL_H */

--- a/src/private/internal.h
+++ b/src/private/internal.h
@@ -151,4 +151,13 @@ struct monome {
 
 void monome_debug(const char * format, ...);
 
+typedef struct { int unused; } * monome_error_t;
+
+#define MONOME_MAX_ERROR_STRING_SIZE 1024
+
+void monome_error_init(monome_error_t * error);
+void monome_error_set(monome_error_t error, const char * format, ...);
+const char * monome_error_get(monome_error_t error);
+void monome_error_uninit(monome_error_t error);
+
 #endif /* defined MONOME_INTERNAL_H */

--- a/wscript
+++ b/wscript
@@ -59,6 +59,19 @@ def check_udev(conf):
 			msg="Checking for libudev",
 			errmsg="no (will use sysfs)")
 
+	conf.check_cc(
+			define_name="HAVE_UDEV_DEVICE_NEW_FROM_DEVICE_ID",
+			mandatory=False,
+			quote=0,
+
+			execute=True,
+
+			function_name='udev_device_new_from_device_id',
+			header_name="libudev.h",
+			uselib="UDEV",
+
+			msg="Checking for function udev_device_new_from_device_id() in libudev")
+
 def check_liblo(conf):
 	conf.check_cc(
 			define_name="HAVE_LO",


### PR DESCRIPTION
With configure-time compile check for udev_device_new_from_device_id(), should fix  build when udev is from systemd older than 189