### PR TITLE
Allow usage of arduinome with OSX 10.8.x

### DIFF
--- a/src/private/devices.h
+++ b/src/private/devices.h
@@ -25,7 +25,10 @@ static monome_devmap_t mapping[] = {
 
 	{"m40h%d",  "40h",    {8, 8},   "monome 40h", NO_QUIRKS},
 	{"a40h-%d", "40h",    {8, 8},   "arduinome" , QUIRK_57600_BAUD},
-
+	
+	/* add compatibility for arduinome on OSX 10.8.x */
+	{"%d", 		"40h",    {8, 8},   "arduinome" , QUIRK_57600_BAUD},
+	
 	/* determine device dimensions in initialization */
 	{"m%d",     "mext",   {0, 0},   "monome i2c", NO_QUIRKS},
 


### PR DESCRIPTION
Since OSX 10.8 arduinomes are not mounted with their flashed serial
number (a40h-0123), but with a simple 8 digit number. This patch allows
detection of such arduinomes but might also lead to the detection of
other non-monome usb devices.
