### PR TITLE
Inhibit warnings from clang driver about unused arguments

### DIFF
--- a/wscript
+++ b/wscript
@@ -149,7 +149,7 @@ def configure(conf):
 		conf.env.append_unique("LINKFLAGS", ["-mmacosx-version-min=10.5"])
 
 	if conf.env.CC[0] == "clang":
-		conf.env.append_unique("CFLAGS", ["-Wno-initializer-overrides"])
+		conf.env.append_unique("CFLAGS", ["-Wno-initializer-overrides", "-Qunused-arguments"])
 
 	conf.env.PROTOCOLS = ["40h", "series", "mext"]
 	if conf.env.LIB_LO:


### PR DESCRIPTION
Here's a fix for building with clang. Details in

https://github.com/monome/libmonome/issues/36
