### PR TITLE
Allows multiple connected devices to use libmonome's osc protocol at once

### DIFF
--- a/src/proto/osc.c
+++ b/src/proto/osc.c
@@ -232,6 +232,7 @@ static int proto_osc_open(monome_t *monome, const char *dev,
 		return 1;
 	}
 
+	lo_send_from(self->outgoing, self->server, LO_TT_IMMEDIATE, "/sys/port","i",atoi(port));
 #define ASPRINTF_OR_BAIL(...) do { \
 	if (asprintf(__VA_ARGS__) < 0) \
 		return -1;                 \


### PR DESCRIPTION
When opening a new osc device, libmonome never tells the target device which port to communicate on.  This caused conflicts when using my monome 512 by itself or with my monome 256: if I was using a non-8000 port, I wouldn't get osc messages at all.   If I was using 8000, traffic from all grids was being directed to my server even though the following address is specified:
monome_t *monome = NULL;
monome = monome_open("osc.udp://127.0.0.1:17537/monome", "8000"); 

Using /dev/ttyUSB0 and /dev/ttyUSB1 worked okay, but that way I can't use serialosc to autoconfigure my monomes.

As seen in my pull request, adding the line:
lo_send_from(self->outgoing, self->server, LO_TT_IMMEDIATE, "/sys/port","i",atoi(port));
at line 235 of src/proto/osc.c seems to be the easiest fix.  