### PR TITLE
Fixes for python bindings

### DIFF
--- a/bindings/python/monome.pyx
+++ b/bindings/python/monome.pyx
@@ -204,8 +204,8 @@ cdef void handler_thunk(const_monome_event_t *event, void *data):
 cdef class Monome(object):
 	cdef monome_t *monome
 
-	cdef str serial
-	cdef str devpath
+	cdef unicode serial
+	cdef unicode devpath
 	cdef int fd
 	cdef list handlers
 

--- a/bindings/python/monome.pyx
+++ b/bindings/python/monome.pyx
@@ -197,12 +197,69 @@ cdef class MonomeGridEvent(MonomeEvent):
 		def __get__(self):
 			return self.y
 
+cdef class MonomeEncoderKeyEvent(MonomeEvent):
+	cdef bool pressed
+	cdef uint number
+
+	def __cinit__(self, pressed, number, object monome):
+		self.monome = monome
+		self.pressed = bool(pressed)
+		self.number = number
+
+	def __repr__(self):
+		return "%s(%s, %d, %d)" % \
+				(self.__class__.__name__, self.pressed, self.number)
+
+	property monome:
+		def __get__(self):
+			return self.monome
+
+	property pressed:
+		def __get__(self):
+			return self.pressed
+
+	property number:
+		def __get__(self):
+			return self.number
+
+cdef class MonomeEncoderEvent(MonomeEvent):
+	cdef uint number
+	cdef int delta
+
+	def __cinit__(self, number, delta, object monome):
+		self.monome = monome
+		self.number = number
+		self.delta = delta
+
+	def __repr__(self):
+		return "%s(%s, %d)" % \
+				(self.__class__.__name__, self.number, self.delta)
+
+	property monome:
+		def __get__(self):
+			return self.monome
+
+	property number:
+		def __get__(self):
+			return self.number
+
+	property delta:
+		def __get__(self):
+			return self.delta
 
 cdef MonomeEvent event_from_event_t(const_monome_event_t *e, object monome=None):
 	if   e.event_type == MONOME_BUTTON_DOWN:
 		return MonomeGridEvent(1, e.grid.x, e.grid.y, monome)
 	elif e.event_type == MONOME_BUTTON_UP:
 		return MonomeGridEvent(0, e.grid.x, e.grid.y, monome)
+	elif e.event_type == MONOME_ENCODER_DELTA:
+		return MonomeEncoderEvent(e.encoder.number, e.encoder.delta, monome)
+	elif e.event_type == MONOME_ENCODER_KEY_DOWN:
+		return MonomeEncoderKeyEvent(1, e.encoder.number, monome)
+	elif e.event_type == MONOME_ENCODER_KEY_UP:
+		return MonomeEncoderKeyEvent(0, e.encoder.number, monome)
+	else:
+		raise RuntimeError('Unknown or unimplemented event_type {}'.format(e.event_type))
 
 	# XXX: handle other event types
 

--- a/examples/test_arc.py
+++ b/examples/test_arc.py
@@ -1,0 +1,54 @@
+import monome
+import time
+
+KNOBS = 4
+BPM = 98
+
+def chill(speed):
+    time.sleep(60000. / (BPM * speed) / 1000)
+
+def test_ring(m, r):
+    map = [0]*64
+
+    for b in xrange(16):
+        m.led_ring_all(r, b)
+        chill(12)
+
+    for i in xrange(-64, 8):
+        m.led_ring_set(r, i & 63, (i >= 0) * 15)
+        chill(40)
+
+    for i in xrange(1, 64):
+        m.led_ring_range(r, i, i + (8 - (i - 55 if i >= 55 else 0)), 15)
+        chill(40)
+        m.led_ring_all(r, 0)
+
+    for i in xrange(80):
+        for b in xrange(64):
+            map[b] = (b - i - 1) & 0xF
+
+        m.led_ring_map(r, map)
+        chill(24)
+
+    for i in xrange(16):
+        for b in xrange(64):
+            map[b] = (map[b] + 1) % (16 - i)
+
+        m.led_ring_map(r, map)
+        chill(32)
+
+def clear_rings(m):
+    for i in xrange(KNOBS):
+        m.led_ring_all(i, 0)
+
+def main():
+    m = monome.Monome('/dev/ttyUSB0')
+    print m.serial
+    print m.devpath
+    clear_rings(m)
+    chill(4)
+
+    test_ring(m, 0)
+
+if __name__ == '__main__':
+    main()

--- a/wscript
+++ b/wscript
@@ -105,6 +105,12 @@ def options(opt):
 			default=False, help="disable OSC/liblo support [enabled by default]")
 	lm_opts.add_option("--enable-python", action="store_true",
 			default=False, help="enable python bindings [disabled by default]")
+	lm_opts.add_option("--python",
+			default=None, help="python to build against")
+	lm_opts.add_option("--pythondir",
+			default=None, help="python to build against")
+	lm_opts.add_option("--pythonarchdir",
+			default=None, help="python to build against")
 	lm_opts.add_option("--enable-multilib", action="store_true",
 			default=False, help="on Darwin, build libmonome as a combination 32 and 64 bit library [disabled by default]")
 	lm_opts.add_option('--enable-debug', action='store_true',


### PR DESCRIPTION
- Not clear why python, pythondir, pythonarchdir options need to be
explicitly definied, but they do.  What should be done here.
- str != unicode.  Seems like a straight forward fix.

