### PR TITLE
Legacy adapter for varibright `/level` messages

### DIFF
--- a/src/proto/series.c
+++ b/src/proto/series.c
@@ -270,10 +270,10 @@ static int proto_series_led_level_all(monome_t *monome, uint_t level) {
 
 static uint8_t reduce_levels_to_bitmask(const uint8_t *levels) {
 	/* levels is expected to be uint8_t[8] */
-	uint_t i, byte;
-	byte = 0;
+	uint_t i;
+	uint8_t byte = 0;
 	for (i = 0; i < 8; i++) {
-		byte |= ((levels[i] > 0) & 0x01) << (7 - i);
+		byte |= ((levels[i] > 7) & 0x01) << i;
 	}
 	return byte;
 };

--- a/src/proto/series.c
+++ b/src/proto/series.c
@@ -256,6 +256,83 @@ static monome_led_functions_t proto_series_led_functions = {
 };
 
 /**
+ * led level functions
+ */
+
+static int proto_series_led_level_set(monome_t *monome, uint_t x, uint_t y,
+                                      uint_t level) {
+	return proto_series_led_set(monome, x, y, (level > 7));
+}
+
+static int proto_series_led_level_all(monome_t *monome, uint_t level) {
+	return proto_series_led_all(monome, (level > 7));
+}
+
+static uint8_t reduce_levels_to_bitmask(const uint8_t *levels) {
+	/* levels is expected to be uint8_t[8] */
+	uint_t i, byte;
+	byte = 0;
+	for (i = 0; i < 8; i++) {
+		byte |= ((levels[i] > 0) & 0x01) << (7 - i);
+	}
+	return byte;
+};
+
+static int proto_series_led_level_map(monome_t *monome, uint_t x_off,
+		uint_t y_off, const uint8_t *data) {
+	uint8_t levels[64];
+	uint8_t masks[8];
+	uint_t i;
+	
+	/* don't rotate coords here like you would in mext, since rotate happens
+	 * in the call to the normal led_map function
+	 */
+	ROTSPEC(monome).level_map_cb(monome, levels, data);
+
+	/* reduce the level data into a bitmask */
+	for (i = 0; i < 8; ++i) {
+		masks[i] = reduce_levels_to_bitmask(&levels[i * 8]);
+	};
+	return proto_series_led_map(monome, x_off, y_off, masks);
+}
+
+
+static int proto_series_led_level_row(monome_t *monome, uint_t x_off,
+		uint_t row, size_t count, const uint8_t *data) {
+	uint_t i, chunks;
+	uint8_t masks[2];
+
+	chunks = count / 8;
+	for (i = 0; i < chunks; ++i) {
+		masks[i] = reduce_levels_to_bitmask(&data[i*8]);
+	}
+
+	return proto_series_led_row(monome, x_off, row, chunks, masks);
+}
+
+static int proto_series_led_level_col(monome_t *monome, uint_t col,
+		uint_t y_off, size_t count, const uint8_t *data) {
+	uint_t i, chunks;
+	uint8_t masks[2];
+
+	chunks = count / 8;
+	for (i = 0; i < chunks; ++i) {
+		masks[i] = reduce_levels_to_bitmask(&data[i*8]);
+	}
+
+	return proto_series_led_col(monome, col, y_off, chunks, masks);
+}
+
+static monome_led_level_functions_t proto_series_led_level_functions = {
+	.set = proto_series_led_level_set,
+	.all = proto_series_led_level_all,
+	.map = proto_series_led_level_map,
+	.row = proto_series_led_level_row,
+	.col = proto_series_led_level_col
+};
+
+
+/**
  * tilt functions
  *
  * see http://post.monome.org/comments.php?DiscussionID=773#Item_5
@@ -356,7 +433,7 @@ monome_t *monome_protocol_new(void) {
 	monome->next_event = proto_series_next_event;
 
 	monome->led = &proto_series_led_functions;
-	monome->led_level = NULL;
+	monome->led_level = &proto_series_led_level_functions;
 	monome->led_ring = NULL;
 	monome->tilt = &proto_series_tilt_functions;
 


### PR DESCRIPTION
This is a (mostly) working proof-of-concept to provide older devices with *some* LED feedback for the varibright `/led/level/**` OSC messages.

Right now, it's only implemented for `series`, but it could be pretty easily added to 40h.

I'm not 100% sure how accurate it is in the bitmapping stage: `/grid/led/level/row` and `/grid/led/level/col` seem to do the right thing, but `/grid/led/level/map` is drawing upside down.

There's also a somewhat arbitrary decision here to use the 50% point as the threshold (i.e. anything "low intensity" stays off, and anything "medium" or "high" intensity turns on).  It might make more sense to make this configurable, so it could be set by serialosc, and therefore by a serialosc config on a per-device basis.