### PR TITLE
Kludge for easier FFI bindings

### DIFF
--- a/examples/simple.c
+++ b/examples/simple.c
@@ -24,7 +24,8 @@
 
 unsigned int grid[16][16] = { [0 ... 15][0 ... 15] = 0 };
 
-#define MONOME_DEVICE "osc.udp://127.0.0.1:8080/monome"
+/* #define MONOME_DEVICE "osc.udp://127.0.0.1:8080/monome" */
+#define MONOME_DEVICE "/dev/ttyUSB0"
 
 /**
  * this function gets registered with monome_register_handler

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -30,12 +30,7 @@ unsigned int grid[16][16] = { [0 ... 15][0 ... 15] = 0 };
  * this function gets registered with monome_register_handler
  * it gets called whenever a button is pressed
  */
-void handle_press(const monome_event_t *e, void *data) {
-	unsigned int x, y;
-
-	x = e->grid.x;
-	y = e->grid.y;
-
+void handle_press(const monome_event_t *e, unsigned int x, unsigned int y) {
 	/* toggle the button */
 	grid[x][y] = !grid[x][y];
 	monome_led_set(e->monome, x, y, grid[x][y]);
@@ -51,7 +46,7 @@ int main(int argc, char *argv[]) {
 	monome_led_all(monome, 0);
 
 	/* register our button press callback */
-	monome_register_handler(monome, MONOME_BUTTON_DOWN, handle_press, NULL);
+	monome_register_button_press(monome, handle_press);
 
 	/* wait for presses! */
 	monome_event_loop(monome);

--- a/examples/simple.c
+++ b/examples/simple.c
@@ -31,7 +31,15 @@ unsigned int grid[16][16] = { [0 ... 15][0 ... 15] = 0 };
  * this function gets registered with monome_register_handler
  * it gets called whenever a button is pressed
  */
-void handle_press(const monome_event_t *e, unsigned int x, unsigned int y) {
+void handle_press(const monome_event_t *e, void *data) {
+	unsigned int x, y;
+
+	x = e->grid.x;
+	y = e->grid.y;
+	grid[x][y] = !grid[x][y];
+	monome_led_set(e->monome, x, y, grid[x][y]);
+}
+void handle_press2(const monome_event_t *e, unsigned int x, unsigned int y) {
 	/* toggle the button */
 	grid[x][y] = !grid[x][y];
 	monome_led_set(e->monome, x, y, grid[x][y]);
@@ -47,8 +55,8 @@ int main(int argc, char *argv[]) {
 	monome_led_all(monome, 0);
 
 	/* register our button press callback */
-	monome_register_button_press(monome, handle_press);
-
+	/* monome_register_button_press(monome, handle_press2); */
+	monome_register_handler(monome, MONOME_BUTTON_DOWN, handle_press, NULL);
 	/* wait for presses! */
 	monome_event_loop(monome);
 

--- a/public/monome.h
+++ b/public/monome.h
@@ -55,6 +55,8 @@ typedef struct monome_event monome_event_t;
 
 typedef void (*monome_event_callback_t)
 	(const monome_event_t *event, void *data);
+typedef void (*monome_button_callback_t)
+        (unsigned int x, unsigned int y);
 
 struct monome_event {
 	monome_t *monome;
@@ -98,6 +100,12 @@ int monome_register_handler(monome_t *monome, monome_event_type_t event_type,
                             monome_event_callback_t, void *user_data);
 int monome_unregister_handler(monome_t *monome,
                               monome_event_type_t event_type);
+
+int monome_register_button_press(monome_t *monome, monome_button_callback_t);
+int unregister_button_press (monome_t *monome);
+int monome_register_button_release(monome_t *monome, monome_button_callback_t);
+int unregister_button_release (monome_t *monome);
+
 int monome_event_next(monome_t *monome, monome_event_t *event_buf);
 int monome_event_handle_next(monome_t *monome);
 void monome_event_loop(monome_t *monome);

--- a/public/monome.h
+++ b/public/monome.h
@@ -56,7 +56,7 @@ typedef struct monome_event monome_event_t;
 typedef void (*monome_event_callback_t)
 	(const monome_event_t *event, void *data);
 typedef void (*monome_button_callback_t)
-        (unsigned int x, unsigned int y);
+	(const monome_event_t *event, unsigned int x, unsigned int y);
 
 struct monome_event {
 	monome_t *monome;

--- a/src/libmonome.c
+++ b/src/libmonome.c
@@ -187,11 +187,11 @@ monome_button_callback_t button_press_callback;
 monome_button_callback_t button_release_callback;
 
 void handle_button_press(const monome_event_t *e, void *data) {
-	button_press_callback(e->grid.x, e->grid.y);
+	button_press_callback(e, e->grid.x, e->grid.y);
 }
 
 void handle_button_release(const monome_event_t *e, void *data) {
-	button_release_callback(e->grid.x, e->grid.y);
+	button_release_callback(e, e->grid.x, e->grid.y);
 }
 
 int monome_register_button_press(monome_t *monome, monome_button_callback_t cb) {

--- a/src/libmonome.c
+++ b/src/libmonome.c
@@ -183,6 +183,47 @@ int monome_register_handler(monome_t *monome, monome_event_type_t event_type,
 	return 0;
 }
 
+monome_button_callback_t button_press_callback;
+monome_button_callback_t button_release_callback;
+
+void handle_button_press(const monome_event_t *e, void *data) {
+	button_press_callback(e->grid.x, e->grid.y);
+}
+
+void handle_button_release(const monome_event_t *e, void *data) {
+	button_release_callback(e->grid.x, e->grid.y);
+}
+
+int monome_register_button_press(monome_t *monome, monome_button_callback_t cb) {
+	button_press_callback = cb;
+	monome_callback_t *handler;
+
+	handler	= &monome->handlers[MONOME_BUTTON_DOWN];
+	handler->cb	= handle_button_press;
+
+	return 0;
+}
+
+int unregister_button_press (monome_t *monome) {
+	button_press_callback = NULL;
+	return monome_unregister_handler(monome, MONOME_BUTTON_DOWN);
+}
+
+int monome_register_button_release(monome_t *monome, monome_button_callback_t cb) {
+	button_release_callback = cb;
+	monome_callback_t *handler;
+
+	handler	= &monome->handlers[MONOME_BUTTON_UP];
+	handler->cb	= handle_button_release;
+
+	return 0;
+}
+
+int unregister_button_release (monome_t *monome) {
+	button_release_callback = NULL;
+	return monome_unregister_handler(monome, MONOME_BUTTON_UP);
+}
+
 int monome_unregister_handler(monome_t *monome,
                               monome_event_type_t event_type) {
 	return monome_register_handler(monome, event_type, NULL, NULL);


### PR DESCRIPTION
I started writing common lisp bindings to libmonome:
https://github.com/rick-monster/cl-monome
... but defining callbacks in common lisp which have to dig into C structs can be a huge pain and it's annoying to add unnecessary C glue code to my bindings.  So I bolted on something to libmonome which allows to define button callbacks with a simpler coordinate signature:

https://github.com/rick-monster/libmonome/blob/master/public/monome.h#L58

This makes it very easy to define callbacks from common lisp:
https://github.com/rick-monster/cl-monome/blob/master/cl-monome.lisp#L77

and keeps the binding simple, without needing to build in a load of knowledge about the underlying data structures in libmonome.  I also modified simple.c to hint the alternative callback mechanism:

https://github.com/rick-monster/libmonome/blob/master/examples/simple.c#L42

Hopefully this addition makes some sense in a broader context!