### PR TITLE
add struct comprehension glue to simplify ffi

### DIFF
--- a/public/monome.h
+++ b/public/monome.h
@@ -128,6 +128,9 @@ int monome_led_level_row(monome_t *monome, unsigned int x_off,
                          unsigned int y, size_t count, const uint8_t *data);
 int monome_led_level_col(monome_t *monome, unsigned int x, unsigned int y_off,
                          size_t count, const uint8_t *data);
+int monome_event_get_grid(const monome_event_t *e,
+			  unsigned int *out_x, unsigned int *out_y,
+			  monome_t **monome);
 
 /**
  * led ring commands

--- a/src/libmonome.c
+++ b/src/libmonome.c
@@ -289,6 +289,13 @@ int monome_led_level_col(monome_t *monome, uint_t x, uint_t y_off,
 	return monome->led_level->col(monome, x, y_off, count, data);
 }
 
+int monome_event_get_grid(const monome_event_t *e, unsigned int *out_x, unsigned int *out_y, monome_t **monome) {
+	*out_x = e->grid.x;
+	*out_y = e->grid.y;
+	*monome = e->monome;
+	return 0;
+}
+
 int monome_led_ring_set(monome_t *monome, uint_t ring, uint_t led,
                         uint_t level) {
 	REQUIRE(led_ring);


### PR DESCRIPTION
OK so this is a much smaller change to libmonome along the lines suggested by @wrl here https://github.com/monome/libmonome/pull/45

it just adds some optional button-press comprehension glue code to libmonome so I don't have to tear my hair out too much trying to figure out how all those crazy structs actually translate into addresses.

cl-monome code comes only moderately terrrible using accessor functions:
https://github.com/rick-monster/cl-monome/blob/master/cl-monome.lisp#L73
but hey CL ffi code is always unsatisfying (to me at least) so think I'm happy enough with this solution...