### PR TITLE
posix: don't process events when read returns < 0

### DIFF
--- a/src/platform/posix.c
+++ b/src/platform/posix.c
@@ -212,7 +212,7 @@ void monome_event_loop(monome_t *monome) {
 			break;
 		}
 
-		if( !monome->next_event(monome, &e) )
+		if( monome->next_event(monome, &e) < 1 )
 			continue;
 
 		handler = &monome->handlers[e.event_type];


### PR DESCRIPTION
i'm using libmonome to read directly from a serial device on linux. 

much to my surprise, at a certain point in the project i started getting segfaults and spurious callbacks on device disconnect, which i never saw before.

currently my test device is a latest-edition 128. 

after digging a bit, i found that `next_event()` is returning `-1` (ultimately from [here](https://github.com/monome/libmonome/blob/master/src/platform/linux.c#L35)), but the event loop just checks for logical zero, so it continues with a bogus event structure, which may or may not blow up spectacularly.

here's a minimal patch that works for me, but maybe there's a better solution