### PR TITLE
Linux sysfs: Check asprintf() return value

### DIFF
--- a/src/platform/linux_sysfs.c
+++ b/src/platform/linux_sysfs.c
@@ -1,10 +1,10 @@
 /**
  * Copyright (c) 2010 William Light <wrl@illest.net>
- * 
+ *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted, provided that the above
  * copyright notice and this permission notice appear in all copies.
- * 
+ *
  * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
  * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
  * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
@@ -68,7 +68,8 @@ char *monome_platform_get_dev_serial(const char *path) {
 
 	path = strchr(path, '/') + 1;
 
-	asprintf(&buf, FTDI_PATH "/*/%s", path);
+	if (asprintf(&buf, FTDI_PATH "/*/%s", path) < 0)
+		goto err_asprintf;
 	glob(buf, 0, NULL, &gb);
 	free(buf);
 
@@ -87,7 +88,8 @@ char *monome_platform_get_dev_serial(const char *path) {
 	return buf;
 
 err_baddev:
-		globfree(&gb);
+	globfree(&gb);
+err_asprintf:
 err_nodevs:
 	return NULL;
 }


### PR DESCRIPTION
Fixes #50

Even though it's not a big change please review thoroughly, I have pretty much zero C experience.
Also not sure about the label name, I used `err_asprintf` couldn't come up with a better name :x

Are there any tests I can run to validate the code?

P.S. The travis build test doesn't actually build this code since the builder has udev available.
I have an additional commit that adds a `--disable-udev` flag to `./waf configure` that allows one to explicitly disable udev. That can also be used to test this code. Shall I add it to this PR or create a separate one for that?