### PR TITLE
Add --disable-udev option to wscript

### DIFF
--- a/wscript
+++ b/wscript
@@ -103,6 +103,8 @@ def options(opt):
 
 	lm_opts.add_option("--disable-osc", action="store_true",
 			default=False, help="disable OSC/liblo support [enabled by default]")
+	lm_opts.add_option("--disable-udev", action="store_true",
+			default=False, help="disable udev support [enabled by default]")
 	lm_opts.add_option("--enable-python", action="store_true",
 			default=False, help="enable python bindings [disabled by default]")
 	lm_opts.add_option("--python",
@@ -147,7 +149,7 @@ def configure(conf):
 		check_poll(conf)
 		conf.check_cc(lib='dl', uselib_store='DL', mandatory=True)
 
-	if conf.env.DEST_OS == "linux":
+	if conf.env.DEST_OS == "linux" and not conf.options.disable_udev:
 		check_udev(conf)
 
 	if not conf.options.disable_osc:


### PR DESCRIPTION
Small change that adds the option to disable udev, forcing the use of sysfs instead.

I mainly added this because for packaging libmonome for gentoo we don't want to have any [automagic dependencies](https://wiki.gentoo.org/wiki/Project:Quality_Assurance/Automagic_dependencies), but this will also allow us to do a build of the sysfs implementation of Travis.

I can add a commit to this PR to enable building the sysfs implementation of Travis or create a separate PR to add it, just let me know what is preferred.