### PR TITLE
return true from monome_platform_is_dev_grid on mac

### DIFF
--- a/src/platform/darwin.c
+++ b/src/platform/darwin.c
@@ -70,6 +70,5 @@ int monome_platform_wait_for_input(monome_t *monome, uint_t msec) {
 
 
 char monome_platform_is_dev_grid(const char *device) {
-    // TODO
-    return 0;
+    return 1;
 }


### PR DESCRIPTION
if mext handshake fails, monome_open will handle the error instead.