### PR TITLE
change blocking/timing

### DIFF
--- a/examples/torture.c
+++ b/examples/torture.c
@@ -28,10 +28,10 @@
 #include <monome.h>
 
 #define MONOME_OSC "osc.udp://127.0.0.1:8080/monome"
-#define MONOME_SERIAL "/dev/ttyUSB0"
+#define MONOME_SERIAL "/dev/ttyACM0"
 
 #define WIDTH  16
-#define HEIGHT 16
+#define HEIGHT 8
 
 void random_chill() {
 	struct timespec rem, req;
@@ -47,7 +47,7 @@ int main(int argc, char **argv) {
 	unsigned int w, h, y, s;
 	uint16_t buf;
 
-	if( !(monome = monome_open(MONOME_OSC, "8000")) ) {
+	if( !(monome = monome_open(MONOME_SERIAL, "8000")) ) {
 		fprintf(stderr, "couldn't open monome\n");
 		exit(EXIT_FAILURE);
 	}

--- a/src/platform/posix.c
+++ b/src/platform/posix.c
@@ -99,7 +99,7 @@ int monome_platform_open(monome_t *monome, const monome_devmap_t *m,
 	struct termios nt, ot;
 	int fd;
 
-	if( (fd = open(dev, O_RDWR | O_NOCTTY | O_NONBLOCK)) < 0 ) {
+	if( (fd = open(dev, O_RDWR | O_NOCTTY)) < 0 ) {
 		perror("libmonome: could not open monome device");
 		return 1;
 	}
@@ -131,8 +131,8 @@ int monome_platform_open(monome_t *monome, const monome_devmap_t *m,
 	nt.c_oflag &= ~(OCRNL | ONLCR | ONLRET | ONOCR |
 	                OFILL | OPOST);
 
-	nt.c_cc[VMIN]  = 1;
-	nt.c_cc[VTIME] = 0;
+	nt.c_cc[VMIN]  = 0;
+	nt.c_cc[VTIME] = 1;
 
 	if( tcsetattr(fd, TCSANOW, &nt) < 0 )
 		goto err_tcsetattr;

--- a/src/platform/posix.c
+++ b/src/platform/posix.c
@@ -132,7 +132,7 @@ int monome_platform_open(monome_t *monome, const monome_devmap_t *m,
 	                OFILL | OPOST);
 
 	nt.c_cc[VMIN]  = 0;
-	nt.c_cc[VTIME] = 1;
+	nt.c_cc[VTIME] = 0;
 
 	if( tcsetattr(fd, TCSANOW, &nt) < 0 )
 		goto err_tcsetattr;


### PR DESCRIPTION
change to blocking.

details, from @trentgill below:

---
after a few sessions of debugging i've found a solution to the problem which is, tl;dr libmonome needs to open the serial port in blocking mode.

i'll post a PR to libmonome, but wanted to run it by y'all first. if you want to confirm on your systems, it's only 3 lines of change in `libmonome/src/platform/posix.c`:

line 102 drops the `O_NONBLOCK` to become:
`if( (fd = open(dev, O_RDWR | O_NOCTTY)) < 0 ) {`

lines 135/136 change timings to be:
`nt.c_cc[VMIN] = 0;`
`nt.c_cc[VTIME] = 1;`

---

now the long story...

after some research, it seems that there is more of a difference between FTDI & CDC on a uC than i thought.

firstly FTDI has a 384byte input buffer. i don't *think* this is the issue bc usb packets should be limited to 64bytes, and we're definitely not running into a rx buffer overflow on the stm.

i *think* what's causing the issue is that FTDI actually implements hardware flow-control, where the ACM interface on stm does not. this is a classical problem of uC implmentations of CDC that i found many references to, but no clear examples of fixing this. it generally seems not to be a problem that people have solved afaik.

i think what this means is that while FTDI was opened in non-blocking mode, the hardware flow control somehow automatically handled cases where you sent more than 64bytes. i'm not totally sure of this bc i didn't trace through the code with an older grid to see if it runs through the same endpoints.

---

to the reasoning behind non-blocking mode...

when the write buffer fills up (64bytes) libmonome just keeps blasting data at the TTY port. i tested sending 64 /led/level messages from a python script and i would see ~18 leds light up correctly, then a break of ~20 leds would be skipped then a single led, then another break. this suggests that the data is being read from the TTY file very quickly, just not as quickly as a fast CPU throwing data as fast as possible.

whenever the buffer was full, libmonome keeps trying to `write` but that call would fail with `EAGAIN` which means "this write failed because it's in non-blocking mode". in other words, the buffer is full and there's no mechanism to apply back-pressure.

anyway - my solution disables the `O_NONBLOCK` flag which means the port will block (but only for a really short time).

i had to change the `VIM` and `VTIME` defines (which previously had no effect because of `O_NONBLOCK`). this means that anytime we ask for data it will be returned instantly if there is any data available, otherwise it will block for 100ms. i'm unclear on how the polling system is implemented in libmonome and didn't dig deeper into that. perhaps we could get away with `VTIME = 0` but there are warnings that this leads to excess CPU usage

more info on vmin & vtime [here](http://unixwiz.net/techtips/termios-vmin-vtime.html).

ok i just tested, and with both vmin & vtime set to `0` CPU usage is still sitting at 0% on my machine in use. with both vtime=0/1 i just had a dumb python script lighting keys while they were held and both are super responsive & serialoscd sits at 0% CPU usage in either case.

vmin *must* be set to `0` otherwise detection doesn't complete until you press a key on the device (otherwise it's blocking, waiting for any amount of data from the device).

lmk if the proposed changes are acceptable. @catfact i imagine you have much more experience with `termios` and any gotchas that i might be ignoring. excited to hear if it solves the problem on norns!

---

my own comments:

this modification works well with my test app, but there are substantial timing ramifications. here's a chart for acm vs. ftdi (in ms):

    16 LEDs: 0.16 vs. 0.08
    32 LEDS: 0.8 vs. 0.1
    128 LEDS: 7.0 vs. 0.5

i've double-checked the decimal points.

visually, the quick-ripple is visible on both FTDI and ACM, so the FTDI hardware+driver really does some buffering/flow magic to unburden the CPU (from a wait state).

while this is initially alarming, i'm particularly concerned as the beyond highly recommended method of updating LEDs is with the size-optimized map messages rather than individual leds (which is enforced on norns) --- which means in practice there should be no change in experience.

i'm considering writing a slightly higher-level set of functions for libmonome which would provide this functionality (keeping an LED buffer, updating on a given timer with a dirty flag), though feedback in the past has tended towards the desire for people to roll their own.

as an alternative (to the above) i'd propose having serialosc enforce the buffer/dirty/timer/map refresh method, so that OSC packets could remain LED/row/map but the actual serial bytes sent would always be map.