### PR TITLE
fix for earlier versions for cython

### DIFF
--- a/bindings/python/monome.pyx
+++ b/bindings/python/monome.pyx
@@ -311,14 +311,13 @@ cdef class Monome:
 		270: ROTATE_270}
 
 	def __init__(self, str device, int port=0, bint clear=True):
-
 		if device[:3] == "osc" and not port:
 			raise TypeError("OSC protocol requires a server port.")
 
 		if port:
-			self.monome = monome_open(<bytes>device.encode(), <bytes>str(port).encode())
+			self.monome = monome_open(<bytes> device.encode(), <bytes> str(port).encode())
 		else:
-			self.monome = monome_open(<bytes>device.encode())
+			self.monome = monome_open(<bytes> device.encode())
 
 		if self.monome is NULL:
 			raise IOError("Could not open Monome")

--- a/bindings/python/monome.pyx
+++ b/bindings/python/monome.pyx
@@ -311,13 +311,17 @@ cdef class Monome:
 		270: ROTATE_270}
 
 	def __init__(self, str device, int port=0, bint clear=True):
+
+		cdef bytes _device = device.encode()
+		cdef bytes _port = str(port).encode()
+
 		if device[:3] == "osc" and not port:
 			raise TypeError("OSC protocol requires a server port.")
 
 		if port:
-			self.monome = monome_open(device.encode(), str(port).encode())
+			self.monome = monome_open(_device, _port)
 		else:
-			self.monome = monome_open(device.encode())
+			self.monome = monome_open(_device)
 
 		if self.monome is NULL:
 			raise IOError("Could not open Monome")

--- a/bindings/python/monome.pyx
+++ b/bindings/python/monome.pyx
@@ -312,16 +312,13 @@ cdef class Monome:
 
 	def __init__(self, str device, int port=0, bint clear=True):
 
-		cdef bytes _device = device.encode()
-		cdef bytes _port = str(port).encode()
-
 		if device[:3] == "osc" and not port:
 			raise TypeError("OSC protocol requires a server port.")
 
 		if port:
-			self.monome = monome_open(_device, _port)
+			self.monome = monome_open(<bytes>device.encode(), <bytes>str(port).encode())
 		else:
-			self.monome = monome_open(_device)
+			self.monome = monome_open(<bytes>device.encode())
 
 		if self.monome is NULL:
 			raise IOError("Could not open Monome")


### PR DESCRIPTION
Includes a fix to the `__init__` method of the `Monome` extension class to allow cython versions earlier than 3.1 such as 3.0.10 to compile `monomer.pyx` without errors. 

Basically, the following works without issues with cython 3.1 and above but causes an error with earlier versions.

```cython
def __init__(self, str device, int port=0, bint clear=True):
		if device[:3] == "osc" and not port:
			raise TypeError("OSC protocol requires a server port.")
		if port:
			self.monome = monome_open(device.encode(), str(port).encode())
		else:
			self.monome = monome_open(device.encode())
```

It has been replaced with the more widely compatible:

```cython
def __init__(self, str device, int port=0, bint clear=True):
		cdef bytes _device = device.encode()
		cdef bytes _port = str(port).encode()

		if device[:3] == "osc" and not port:
			raise TypeError("OSC protocol requires a server port.")
		if port:
			self.monome = monome_open(_device, _port)
		else:
			self.monome = monome_open(_device)
```



